### PR TITLE
Update InterestsSelect styling with new design system

### DIFF
--- a/src/components/InterestsSelect/InterestsSelect.jsx
+++ b/src/components/InterestsSelect/InterestsSelect.jsx
@@ -9,14 +9,16 @@ const components = {
 const customStyles = {
   control: (provided, state) => ({
     ...provided,
-    boxShadow: 'inset 0 0.0625em 0.125em rgb(10 10 10 / 5%)',
-    backgroundColor: '#F8F8FF',
-    ...(state.isFocused
-      ? {
-          borderColor: '#3273dc',
-          boxShadow: '0 0 0 0.125em rgb(50 115 220 / 25%)',
-        }
-      : {}),
+    backgroundColor: '#ffffff',
+    borderWidth: '2px',
+    borderColor: '#000000',
+    borderRadius: '0.5rem',
+    boxShadow: state.isFocused
+      ? '0 0 0 2px #ffffff, 0 0 0 4px #000000'
+      : 'none',
+    '&:hover': {
+      borderColor: '#000000',
+    },
   }),
 }
 


### PR DESCRIPTION
## Summary
Updated the `InterestsSelect` component's custom styles to implement a new visual design with improved focus states and border styling.

## Key Changes
- Changed background color from `#F8F8FF` (ghost white) to `#ffffff` (pure white)
- Replaced subtle inset shadow with explicit `2px` black borders
- Added `0.5rem` border radius for rounded corners
- Redesigned focus state with a double-ring outline effect (`2px` white inner ring, `4px` black outer ring)
- Removed the previous blue focus color (`#3273dc`) in favor of black
- Simplified hover state to maintain consistent black border color
- Changed default box shadow from inset shadow to `none`

## Implementation Details
The new styling provides a more prominent, accessible focus indicator with the double-ring pattern, making the component's interactive state more visually distinct. The design shifts from a subtle, light aesthetic to a bolder, higher-contrast approach with black borders and outlines.

https://claude.ai/code/session_01AQ6DaVuiYBYUeDHtRY2rau